### PR TITLE
Hotfix: Struct | Handle edge cases on encoding values

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -20,6 +20,7 @@ const (
 	skipUpdate          = "skip_update"
 	skipInsert          = "skip_insert"
 	skipReturningDelete = "skip_delete"
+	skipCompare         = "skip_compare"
 	// if the field is of type time.Time it will inject time.Now
 	defaultNow = "now"
 	// Same as default now but will inject time.Now().UTC()
@@ -35,8 +36,13 @@ func encodeValues(v any, skipType string, skipZeroValues bool) map[string]SQLVal
 			continue
 		}
 		value := t.FieldByName(f.Name)
-		if skipZeroValues && reflect.Zero(f.Type).Equal(value) {
+		if value.IsZero() {
 			continue
+		}
+		if !strings.Contains(f.Tag.Get(tagName), skipCompare) {
+			if skipZeroValues && reflect.Zero(f.Type).Equal(value) {
+				continue
+			}
 		}
 		switch {
 		case strings.Contains(f.Tag.Get(tagName), defaultNowUtc):

--- a/struct.go
+++ b/struct.go
@@ -36,6 +36,7 @@ func encodeValues(v any, skipType string, skipZeroValues bool) map[string]SQLVal
 			continue
 		}
 		value := t.FieldByName(f.Name)
+		// We want to support the case when there is no value in one of the fields
 		if !strings.Contains(f.Tag.Get(tagName), skipCompare) {
 			if value.IsZero() || skipZeroValues && reflect.Zero(f.Type).Equal(value) {
 				continue

--- a/struct.go
+++ b/struct.go
@@ -36,11 +36,8 @@ func encodeValues(v any, skipType string, skipZeroValues bool) map[string]SQLVal
 			continue
 		}
 		value := t.FieldByName(f.Name)
-		if value.IsZero() {
-			continue
-		}
 		if !strings.Contains(f.Tag.Get(tagName), skipCompare) {
-			if skipZeroValues && reflect.Zero(f.Type).Equal(value) {
+			if value.IsZero() || skipZeroValues && reflect.Zero(f.Type).Equal(value) {
 				continue
 			}
 		}

--- a/struct.go
+++ b/struct.go
@@ -38,7 +38,7 @@ func encodeValues(v any, skipType string, skipZeroValues bool) map[string]SQLVal
 		value := t.FieldByName(f.Name)
 		// We want to support the case when there is no value in one of the fields
 		if !strings.Contains(f.Tag.Get(tagName), skipCompare) {
-			if skipZeroValues && reflect.Zero(f.Type).Equal(value) {
+			if skipZeroValues && value.IsZero() {
 				continue
 			}
 		}

--- a/struct.go
+++ b/struct.go
@@ -38,7 +38,7 @@ func encodeValues(v any, skipType string, skipZeroValues bool) map[string]SQLVal
 		value := t.FieldByName(f.Name)
 		// We want to support the case when there is no value in one of the fields
 		if !strings.Contains(f.Tag.Get(tagName), skipCompare) {
-			if value.IsZero() || skipZeroValues && reflect.Zero(f.Type).Equal(value) {
+			if skipZeroValues && reflect.Zero(f.Type).Equal(value) {
 				continue
 			}
 		}

--- a/struct_test.go
+++ b/struct_test.go
@@ -61,10 +61,7 @@ func TestEncodeValues(t *testing.T) {
 		{
 			name: "encode_map_values",
 			model: struct {
-				IntField   int
-				FloatField float64
-				unexported bool
-				MapValue   map[string]any `goqux:"skip_compare"`
+				MapValue map[string]any `goqux:"skip_compare"`
 			}{MapValue: map[string]any{"type": "map"}},
 			values:         map[string]SQLValuer{"map_value": {map[string]any{"type": "map"}}},
 			skipFlag:       skipInsert,
@@ -83,7 +80,7 @@ func TestEncodeValues(t *testing.T) {
 			}{},
 			values:         map[string]SQLValuer{},
 			skipFlag:       skipInsert,
-			skipZeroValues: false,
+			skipZeroValues: true,
 		},
 	}
 	for _, tt := range tableTests {

--- a/struct_test.go
+++ b/struct_test.go
@@ -58,6 +58,33 @@ func TestEncodeValues(t *testing.T) {
 			skipFlag:       skipInsert,
 			skipZeroValues: true,
 		},
+		{
+			name: "encode_map_values",
+			model: struct {
+				IntField   int
+				FloatField float64
+				unexported bool
+				MapValue   map[string]any `goqux:"skip_compare"`
+			}{MapValue: map[string]any{"type": "map"}},
+			values:         map[string]SQLValuer{"map_value": {map[string]any{"type": "map"}}},
+			skipFlag:       skipInsert,
+			skipZeroValues: false,
+		},
+		{
+			name: "encode_empty_struct",
+			model: struct {
+				IntField    int
+				FloatField  float64
+				unexported  bool
+				EmptyStruct struct {
+					Type  string
+					Value string
+				}
+			}{},
+			values:         map[string]SQLValuer{},
+			skipFlag:       skipInsert,
+			skipZeroValues: false,
+		},
 	}
 	for _, tt := range tableTests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Did the following:
 - Handle case when there is not comparable object (such map[...]any)
 - Handle case when one of the struct property is nil and is struct itself.