### PR TITLE
Add WithUpdateReturning function to specify columns to return

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,24 @@
 run:
   tests: true
-  skip-dirs:
+
+issues:
+  exclude-dirs:
     - bin
     - docs
     - example
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - dupl
+        - unused
 
 linters-settings:
   errcheck:
-    ignore: fmt:.*,[rR]ead|[wW]rite|[cC]lose,io:Copy
+    exclude-functions:
+      - fmt:.*
+      - "[rR]ead|[wW]rite|[cC]lose"
+      - io:Copy
 
 linters:
   disable-all: true
@@ -26,11 +37,3 @@ linters:
     - prealloc
     - unconvert
     - unused
-
-issues:
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - dupl
-        - unused

--- a/update.go
+++ b/update.go
@@ -27,6 +27,16 @@ func WithUpdateReturningAll() UpdateOption {
 	}
 }
 
+func WithUpdateReturning(columns ...string) UpdateOption {
+	return func(table exp.IdentifierExpression, s *goqu.UpdateDataset) *goqu.UpdateDataset {
+		cols := make([]any, 0, len(columns))
+		for _, c := range columns {
+			cols = append(cols, table.Col(c))
+		}
+		return s.Returning(cols...)
+	}
+}
+
 func WithUpdateSet(value any) UpdateOption {
 	return func(table exp.IdentifierExpression, s *goqu.UpdateDataset) *goqu.UpdateDataset {
 		return s.Set(value)

--- a/update_test.go
+++ b/update_test.go
@@ -54,6 +54,13 @@ func TestBuildUpdate(t *testing.T) {
 			expectedArgs:  []interface{}{int64(5)},
 		},
 		{
+			name:          "update_with_specific_returning",
+			dst:           updateModel{IntField: 5},
+			options:       []goqux.UpdateOption{goqux.WithUpdateReturning("int_field", "another_col_name")},
+			expectedQuery: `UPDATE "update_models" SET "int_field"=$1 RETURNING "update_models"."int_field", "update_models"."another_col_name"`,
+			expectedArgs:  []interface{}{int64(5)},
+		},
+		{
 			name:          "update_with_zero_values",
 			dst:           updateModel{IntField: 0},
 			expectedQuery: ``,


### PR DESCRIPTION
## Changes
- Added `WithUpdateReturning` function in `update.go` that accepts column names and builds a RETURNING clause with those specific columns
- Added a test case in `update_test.go` to verify the functionality works as expected